### PR TITLE
Quick typo fix

### DIFF
--- a/src/propresenter.ts
+++ b/src/propresenter.ts
@@ -47,7 +47,7 @@ export class ProPresenter {
       .then((response) => {
         resultObj.status = response.status;
         const contentType = response.headers.get("content-type");
-        if (contentType && contentType.indexOf("application/json") !== -1) // Check if response from Pro7 contains a JSON body. Some Pro7 API requests (eg most /trigger's) return only a header without any response body
+        if (contentType && contentType.indexOf("application/json") !== -1) // Check if response from Pro7 contains a JSON body. Some Pro7 API GET requests (eg most /trigger's) return only a header without any response body
           return response.json();
         else
           return JSON.stringify(null);  // Convention: For responses from Pro7 that do not have a body, return "null"
@@ -124,7 +124,7 @@ export class ProPresenter {
    * Requests the current state of the active announcement timeline.
    * @returns The current state of the active announcement timeline.
    */
-  announcementGetActiveTimelineOperation() {
+  announcementGetActiveTimelineOperation() { // TODO: fix this name
     return this.sendRequestToProPresenter(`/v1/announcement/active/timeline`);
   }
   /**

--- a/src/propresenter.ts
+++ b/src/propresenter.ts
@@ -1404,7 +1404,7 @@ export class ProPresenter {
    */
   stageLayoutMapSet() {
     return this.sendRequestToProPresenter(`/v1/stage/layout_map`, {
-      methid: "PUT",
+      method: "PUT",
     });
   }
   /**


### PR DESCRIPTION
Hi @JeffreyDavidsz  
Just doing a quick typo fix before adding a significant feature that provides an easy way to register callbacks for responses sent via `/v1/status/updates`  (no need for websocket to get asychronous status updates)